### PR TITLE
Update devdocker image versioning to avoid version number conflicts.

### DIFF
--- a/devdocker
+++ b/devdocker
@@ -38,15 +38,16 @@
 #   Usage: devdocker portfwd <container port> [<host port>]
 
 import argparse
+import datetime
 import os
 import pipes
+import uuid
 import shutil
 import socket
 import subprocess
 import sys
 import tempfile
 import time
-import uuid
 
 kCfgFileName = '.devdockercfg'
 kMyCfgFileName = '.mydevdockercfg'
@@ -197,12 +198,24 @@ def shellFn(args, unknownArgs):
 def mkImgFn(args, unknownArgs):
   cfg = readConfig()
   subprocess.check_call(
-      ['docker', 'image', 'build', '--tag=%s' % cfg.imageTag,
+      ['docker', 'image', 'build',
        '-f', cfg.dockerFile, os.path.dirname(cfg.dockerFile)])
-  print '\n\nSuccessfully created image: %s' % cfg.imageTag
-  print 'Publish image to repository using the following commands: '
-  print '  $ docker login ' + cfg.registry
-  print '  $ docker push ' + cfg.imageTag
+  # We issue the same build again with -q to get imageDigest. Because of
+  # docker caching this command will execute quite quickly.
+  imgDigest = subprocess.check_output(
+      ['docker', 'image', 'build', '-q',
+       '-f', cfg.dockerFile, os.path.dirname(cfg.dockerFile)]).strip()
+  newImageTag = '%s/%s:%s' % (
+      cfg.registry,
+      cfg.imageName,
+      datetime.datetime.now().strftime("%Y-%m-%d") + "-" + imgDigest[7:19])
+  subprocess.check_call(
+      ['docker', 'tag', imgDigest, newImageTag])
+  print '\n\nSuccessfully created image: %s' % newImageTag
+  print 'Login to the docker registry and publish image using the'
+  print 'following command: '
+  print '  $ docker push ' + newImageTag
+  print 'Update `imageVersion` in .devdockercfg to ' + newImageTag
 
 def portfwdFn(args, unknownArgs):
   try:

--- a/devdocker
+++ b/devdocker
@@ -205,17 +205,16 @@ def mkImgFn(args, unknownArgs):
   imgDigest = subprocess.check_output(
       ['docker', 'image', 'build', '-q',
        '-f', cfg.dockerFile, os.path.dirname(cfg.dockerFile)]).strip()
-  newImageTag = '%s/%s:%s' % (
-      cfg.registry,
-      cfg.imageName,
-      datetime.datetime.now().strftime("%Y-%m-%d") + "-" + imgDigest[7:19])
+  newImageVersion =\
+      datetime.datetime.now().strftime("%Y-%m-%d") + "-" + imgDigest[7:19]
+  newImageTag = '%s/%s:%s' % (cfg.registry, cfg.imageName, newImageVersion)
   subprocess.check_call(
       ['docker', 'tag', imgDigest, newImageTag])
   print '\n\nSuccessfully created image: %s' % newImageTag
   print 'Login to the docker registry and publish image using the'
   print 'following command: '
   print '  $ docker push ' + newImageTag
-  print 'Update `imageVersion` in .devdockercfg to ' + newImageTag
+  print 'Update `imageVersion` in .devdockercfg to ' + newImageVersion
 
 def portfwdFn(args, unknownArgs):
   try:


### PR DESCRIPTION
In the new schema we use a combination of date + image digest as the
version number instead of a monotonically increasing numeric version
number.