### PR TITLE
portfwd: add support for 'network'

### DIFF
--- a/devdocker
+++ b/devdocker
@@ -319,10 +319,15 @@ def portfwdFn(args, unknownArgs):
         'docker', 'inspect', cfg.containerName, '--format',
         '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'])
     hostPort = args.containerPort if args.hostPort == 0 else args.hostPort
-    subprocess.check_call([
-        'docker', 'run', '--rm', '-p', '%d:1234' % hostPort, 'verb/socat',
-        'TCP-LISTEN:1234,fork',
-        'TCP-CONNECT:%s:%d' % (ip, args.containerPort)])
+    networkFlags = []
+    if 'network' in dir(cfg):
+      networkFlags = [ '--network', cfg.network ]
+    subprocess.check_call(
+        ['docker', 'run', '--rm', '-p', '%d:1234' % hostPort] +
+        networkFlags +
+        ['verb/socat'] +
+        ['TCP-LISTEN:1234,fork',
+         'TCP-CONNECT:%s:%d' % (ip, args.containerPort)])
   except KeyboardInterrupt:
     pass
 


### PR DESCRIPTION
*Testing Done*

- Create devdocker container with a default `network`.
- Start a service (Jupyter) inside devdocker container listening on an unused port.
- `devdocker portfwd 8888` runs indefinitely forwarding 8888 between container and host.
- Visit port 8888 on host (http://127.0.0.1:8888/) and access the service's frontend.