### PR TITLE
Deshwal/misc

### DIFF
--- a/devdocker
+++ b/devdocker
@@ -281,9 +281,14 @@ RUN mkdir -p $SRCDIR && sudo chown devdocker:devdocker $SRCDIR
     if 'ports' in dir(cfg):
       for p in cfg.ports:
         portFlags.extend(['-p', p])
-    # Delete any existing container with the provided containerName
+    # Delete any existing container with the provided containerName. We
+    # first kill the container because we have observed that `docker rm -f`
+    # can sometimes take a long time to execute.
     subprocess.call(
-        ['docker', 'rm', '-f', cfg.containerName],
+        ['docker', 'kill', cfg.containerName],
+        stdout = devnull, stderr = devnull)
+    subprocess.call(
+        ['docker', 'rm', cfg.containerName],
         stdout = devnull, stderr = devnull)
     subprocess.check_call(
         ['docker', 'run', '-d', '-i', '-t' ] +

--- a/devdocker
+++ b/devdocker
@@ -236,6 +236,7 @@ RUN mkdir -p $SRCDIR && sudo chown devdocker:devdocker $SRCDIR
     ]
     kDevNull = open(os.devnull, 'w')
     if 'mutagen' in dir(cfg) and cfg.mutagen:
+      print 'Terminating mutagen project ...'
       subprocess.call(
           ['mutagen', 'project', 'terminate'],
           stdout = kDevNull,


### PR DESCRIPTION
- change devdocker deletion sequence upon `devdocker create`
- print log message when mutagen project terminate command is executed so we know that the command has hanged.